### PR TITLE
Declare ReadFromFD in rand_util_posix.cc as static

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 	#	"MinSizeRel" "RelWithDebInfo")
 endif()
 
-set(COMMON_C_FLAGS "${COMMON_C_FLAGS} -Wall")
+set(COMMON_C_FLAGS "${COMMON_C_FLAGS} -Wall -fpic")
 
 set(COMMON_DEBUG_FLAGS "-gdwarf-4")
 set(COMMON_RELEASE_FLAGS "")

--- a/src/base/rand_util_posix.cc
+++ b/src/base/rand_util_posix.cc
@@ -46,7 +46,11 @@ uint64_t RandUint64() {
   return number;
 }
 
-bool ReadFromFD(int fd, char* buffer, size_t bytes) {
+// ReadFromFD is originally defined in base/files/file_util.h
+// libquic removed base/files/file_util.h dependency and copied the function
+// here. Use static to avoid linker conflict in other projects using libquic
+// along with chromium sources.
+static bool ReadFromFD(int fd, char* buffer, size_t bytes) {
   size_t total_read = 0;
   while (total_read < bytes) {
     ssize_t bytes_read =


### PR DESCRIPTION
Use static to avoid linker conflict in other projects using libquic
along with chromium sources.